### PR TITLE
(chore) Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Kesavan Yogeswaran <hikes@google.com>"]
 description = "Bindings to OpenCSD, an ARM CoreSight trace decoder"
 license = "Apache-2.0"
 categories = ["external-ffi-bindings"]
-homepage = "https://github.com/kesyog/opencsd-sys"
+repository = "https://github.com/kesyog/opencsd-sys"
 exclude = [
   "vendor/OpenCSD/decoder/build",
   "vendor/OpenCSD/decoder/docs",


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/88